### PR TITLE
Permit using a custom fetch function that may be passed via the constructor options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,9 @@ export default class Fetchja {
     // Interceptors
     this.onResponseError = error => error
 
+    // Custom Fetch
+    this.fetchFunction = options.fetch || fetch
+
     // Alias
     this.fetch = this.get
     this.update = this.patch
@@ -91,6 +94,8 @@ export default class Fetchja {
     headers: {}
   }) {
     const baseURL = this.baseURL || options.baseURL
+
+    const fetchFunction = options.fetch || this.fetchFunction
 
     const url = new URL(
       options.url.startsWith('/') ? options.url.slice(1) : options.url,
@@ -119,7 +124,7 @@ export default class Fetchja {
       })
 
       // Fetch
-      return fetch(url, {
+      return fetchFunction(url, {
         method: options.method,
         body: options.body,
         headers


### PR DESCRIPTION
A convenience for [integration into SvelteKit](https://kit.svelte.dev/docs/load#making-fetch-requests).

Example use in a SvelteKit universal load function:
```
// src/routes/items/[id]/+page.js
import Fetchja from 'fetchja';
/** @type {import('./$types').PageLoad} */
export async function load({ fetch, params }) {
  const api = new Fetchja({
    baseURL: 'https://localhost/',
    fetch: fetch,
  });

  const data = await api.get(`/api/items/${params.id}`);

  return { data };
}
```

A simple test:
```
import Fetchja from 'fetchja';

const api = new Fetchja({
  baseURL: 'https://localhost/',
  fetch: (url) => {
    console.log(url)
    return Promise.resolve({ ok: true, headers: [], data: [] })
  },
})

await api.get('/asdf')
```