### PR TITLE
Update serialize.js to correct handling of relationships

### DIFF
--- a/src/utils/serialize.js
+++ b/src/utils/serialize.js
@@ -6,7 +6,14 @@ function serializeNode (node, key, data) {
       data.relationships = {}
     }
 
-    const serializeEntity = (entity) => (entity.id ? { id: entity.id, type: entity.type || key } : entity)
+    const serializeEntity = (entity) => (
+      entity.id
+        ? { id: entity.id, type: entity.type || key }
+        : ( Object.keys(entity).length
+           ? entity // object without ID or type will surely not pass validation
+           : null // encode as null to signal relationship removal
+         )
+    )
 
     data.relationships[key] = {
       data: Array.isArray(node) ? node.map(serializeEntity) : serializeEntity(node),

--- a/src/utils/serialize.js
+++ b/src/utils/serialize.js
@@ -6,8 +6,10 @@ function serializeNode (node, key, data) {
       data.relationships = {}
     }
 
+    const serializeEntity = (entity) => (entity.id ? { id: entity.id, type: entity.type || key } : entity)
+
     data.relationships[key] = {
-      data: node.id ? { id: node.id, type: node.type || key } : node,
+      data: Array.isArray(node) ? node.map(serializeEntity) : serializeEntity(node),
       links: node.links,
       meta: node.meta
     }


### PR DESCRIPTION
Corrects serialization of one-to-many relationship, e.g. when serializing a structure like this:

```
{
    "id": "5",
    "title": "Welcome!",
    "type": "calendar-event",
    "participantCalendars": [
        {
            "id": "9",
            "type": "calendar",
            "name": "Rando",
            "color": "#b1a0c6",
        },
        {
            "id": "11",
            "type": "calendar",
            "name": "Bobert",
            "color": "#404040",
        }
    ],
    "calendar": {
        "id": "5",
        "type": "calendar",
        "name": "Froo",
        "color": "#ff0000",
    }
}
```

In addition, fetchja will now correctly serialize empty nested objects to null. For example, the following structure ...

```
{
    "id": "5",
    "title": "Welcome!",
    "type": "calendar-event",
    "calendar": {}
}
```

... will be serialized as follows:

```
{
    "id": "5",
    "type": "calendar-event",
    "attributes": {
        "title": "Welcome!",
    },
    "relationships" : {
        "calendar": { "data": null }
    }
}
```